### PR TITLE
include stdexcept

### DIFF
--- a/src/file_io.cpp
+++ b/src/file_io.cpp
@@ -5,6 +5,7 @@
 #include <cstring>
 #include <cerrno>
 #include <fstream>
+#include <stdexcept>
 
 
 namespace {


### PR DESCRIPTION
Otherwise I get a compilation error

```
error: ‘runtime_error’ is not a member of ‘std’
```